### PR TITLE
Updates to byte-sized RSE page

### DIFF
--- a/_pages/events/byte-sized-rse.md
+++ b/_pages/events/byte-sized-rse.md
@@ -75,12 +75,17 @@ topic that we've not yet covered, you can get in touch with
     <p style="font-size: 0.7em; margin-bottom: 0;"><strong>Date: </strong>{{ episode.date | date: "%A %e %B, %Y &nbsp;" }}{{ episode.time-range }}</p>
     <p style="font-size: 0.7em; margin-bottom: 0;"><strong>Instructors: </strong>{{ episode.instructors }}</p>
     <p style="font-size: 0.7em; margin-bottom: 0;"><strong>Links: </strong>
+      <ul style="font-size: 0.7em; margin: 0 auto;">
       {% if episode.slides %}
-        <a href="{{ episode.slides }}">Slides</a>{% if episode.podcast %},{% endif%}
+        <li style="font-size: 0.9em; margin-bottom: 0;">Slides: <a href="{{ episode.slides }}" target="_blank" rel="noopener noreferrer">Intro slides</a></li>
+      {% endif %}
+      {% if episode.slides_tutorial %}
+        <li style="font-size: 0.9em; margin-bottom: 0;">Slides: <a href="{{ episode.slides_tutorial }}" target="_blank" rel="noopener noreferrer">Tutorial slides</a></li>
       {% endif %}
       {% if episode.podcast %}
-        <a href="{{ episode.podcast }}">Code for Thought podcast</a>
+        <li style="font-size: 0.9em; margin-bottom: 0;">Podcast: <a href="{{ episode.podcast }}" target="_blank" rel="noopener noreferrer">Code for Thought podcast episode</a></li>
       {% endif %}
+      </ul>
     </p>
 
     <div style="font-size: 0.7em;">

--- a/collections/_bytesized_rse/20231205-django-web-dev.md
+++ b/collections/_bytesized_rse/20231205-django-web-dev.md
@@ -7,8 +7,9 @@ image_caption: <small>Photo by <a href="https://unsplash.com/@ilyapavlov">Ilya P
 date: 05-12-2023 13:00 GMT
 time-range: <a href="https://www.timeanddate.com/worldclock/fixedtime.html?msg=Byte-sized+RSE+Season+2%2C+Session+2+-+Python+Web+Application+Development+with+Django&iso=20231205T13&p1=136&ah=1&am=30" target="_blank" rel="noopener noreferrer">13:00-14:30 GMT</a>
 instructors: Jeremy Cohen and Steve Crouch
-slides: 
-podcast: 
+slides: https://docs.google.com/presentation/d/1WtlGFqPmy45nfd4_CugB6LgrUdwln4hCT5EtFVc8acc/edit?usp=sharing
+slides_tutorial: https://docs.google.com/presentation/d/1iJbvh2mPHvGbWcPrKDSZ2Jx_k_sZ9Pzi9q5N0aMeCgk/edit?usp=sharing
+podcast: https://codeforthought.buzzsprout.com/1326658/14092409-en-bytesized-rse-web-development-with-django
 ---
 
 This session looks at the development of web applications with Python using the
@@ -20,7 +21,3 @@ structures and then look at where Django fits in and its architecture.
 After looking at the structure of Django and the different parts of a Django
 application, we'll move on to the interactive part of the session where you'll
 have a chance to build a simple Django web application from scratch!
-
-(Please check session prerequisites on the registration page)
-
-[Register here](https://forms.gle/2VHW8Vjqdkec32g26)


### PR DESCRIPTION
This PR updates the byte sized RSE page as follows:
 - Modifies the layout of the links for byte-sized RSE session entries
 - Adds a new `slides_tutorial:` front-matter tag for byte-sized RSE items that can be used to provide a link to the slides for the interactive tutorial element of a session.
 - Adds the links for the S2 E2 episode on Django.