### PR TITLE
add event page for Imperial seminar

### DIFF
--- a/_pages/events/2024-02-29_seminar-imperial.md
+++ b/_pages/events/2024-02-29_seminar-imperial.md
@@ -1,0 +1,49 @@
+---
+layout: single
+classes: wide
+title: UNIVERSE-HPC Project Seminar Series
+permalink: /events/upcoming-events/2024-02-29_seminar-imperial/
+author_profile: false
+
+
+---
+
+## Widening participation in education - what can we learn post-pandemic?
+
+**Join us for the next UNIVERSE-HPC seminar on Thursday 29 February at
+15:00 GMT**. This is a hybrid event; you can join us online or in person at the Huxley Building on the South Kensington Campus of Imperial College London.
+
+### [Register now](https://forms.office.com/e/b8uFc9kZ97).
+
+## Overview:
+
+- 🕒 **Thursday 29th February** 2024, **15:00 - 16:00** (followed by networking session from 16:00 - 17:00)
+- 📌 **Imperial College London, Room 658**, Huxley Building, South Kensington Campus, & Online
+- 🗣️ **Mishka Nemes**, Skills and Training Manager at The Alan Turing Institute.
+
+
+This talk will walk you through a series of educational examples where programmes such as summer schools, live workshops, term-long courses, longitudinal programmes and others, have changed tack post-pandemic, enabling more people to access learning opportunities on data science and AI. These examples will provide a starting point for open discussion with educators in the audience, aiming to share good practice and to draw inspiration from existing efforts to widen participation in education.
+
+**Speaker bio**: Mishka works at the intersection between AI, Skills and Education. She is interested in Responsible AI practices, deep-tech innovation within AI, as well in building human-centred open access products with the user communities at the very core. Mishka has a background in computational neuroscience & genetics and is most keen to bridge the gap & build connections between her interests and areas of expertise mentioned here.
+
+Please read [our event privacy notice](https://www.imperial.ac.uk/media/imperial-college/administration-and-support-services/secretariat/public/ICL---Events-privacy-notice---10-October-2018.pdf).
+
+#### Join our email list
+
+To stay in touch with our project activities and plans you can subscribe to our
+UNIVERSE-HPC project mailing list:
+
+<a
+href="mailto:sympa@mlist.is.ed.ac.uk?body=SUBSCRIBE%20universe-hpc%20FIRSTNAME%20SURNAME%20%0A%0AQUIT%0A%0A">Subscribe
+via email</a> <small>_(Clicking this link will create a new email to send a
+subscription request to join the mailing list. Leave the email subject blank
+and replace FIRSTNAME and SURNAME with your firstname and surname and then send
+the email to join the list.)_</small>
+
+<small>You can find [further
+information](https://www.ed.ac.uk/information-services/computing/comms-and-collab/email/lists/sympa/subscribe)
+on subscribing to a "Sympa" mailing list on the University of Edinburgh
+website.</small>
+
+If you have any problems joining the mailing list please contact us at
+[our email](mailto:s.sukhiani@epcc.ed.ac.uk) to be added manually.


### PR DESCRIPTION
Added a page for the seminar to take place at Imperial on 29 February.
Will this be automatically shown in the "upcoming events" section of the website?