### PR TITLE
Byte-sized info and front page news update

### DIFF
--- a/_pages/events/byte-sized-rse.md
+++ b/_pages/events/byte-sized-rse.md
@@ -37,12 +37,12 @@ topic that we've not yet covered, you can get in touch with
   {% assign post_date = episode.date | date: '%s' %}
   {% if mention_future == "no" and post_date >= current_date %}
   <div>
-    <h2>Future Byte-sized RSE events</h2>
+    <h2 id="future-sessions">Future Byte-sized RSE events</h2>
   </div>
   {% assign mention_future = "yes" %}
   {% elsif mention_previous == "no" and post_date < current_date %}
   <div>
-    <h2>Past Byte-sized RSE events</h2>
+    <h2 id="past-sessions">Past Byte-sized RSE events</h2>
   </div>
   {% assign mention_previous = "yes" %}
   {% endif %}

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -25,7 +25,7 @@ intro:
       <br/>
       <strong style="font-size: 0.8rem">News: </strong>
       </div>
-      <div style="font-size: 0.6rem; margin-bottom: 14px;">Our 2023-2024 season of monthly <a href="/events/byte-sized-rse/">byte-sized RSE sessions</a> is underway.</div>
+      <div style="font-size: 0.6rem; margin-bottom: 14px;">Our 2024-2025 season of <a href="/events/byte-sized-rse/#future-sessions">byte-sized RSE sessions</a> runs from November 2024, starting with a session on using containers with podman.</div>
 
 
 feature_row:

--- a/collections/_bytesized_rse/20241127-containers.md
+++ b/collections/_bytesized_rse/20241127-containers.md
@@ -25,4 +25,4 @@ However, if you're keen to work with Docker, the material that we cover in this 
 
 **Prerequisites**: In order to be able to participate in the practical/interactive part of this session, you’ll need to install and test podman on your computer prior to the session.
 
-There are detailed [instructions about installing podman](https://podman.io/docs/installation) on the podman website but we've also provided some futher information on podman, why we've chosen to use it and installing podman on Linux, macOS or Windows at: https://www.universe-hpc.ac.uk/resources/byte-sized-rse/podman-info
+There are detailed [instructions about installing podman](https://podman.io/docs/installation) on the podman website but we've also provided some futher information on podman, why we've chosen to use it and installing podman on Linux, macOS or Windows at: [https://www.universe-hpc.ac.uk/resources/byte-sized-rse/podman-info](https://www.universe-hpc.ac.uk/resources/byte-sized-rse/podman-info)


### PR DESCRIPTION
This PR makes the following minor changes to the byte-sized RSE-related content:

 - Make URL included in the containers session a clickable link
 - Update the front page news item to refer to the 2024-25 byte-sized season
 - Add link anchors to the future and past byte-sized session headings on the event page so that the news page link can go directly to the upcoming session(s).